### PR TITLE
Converted functions to declarations, and separated definitions

### DIFF
--- a/print_reverse.c
+++ b/print_reverse.c
@@ -1,0 +1,21 @@
+#include "print_reverse.h"
+#include <string.h>
+#include <unistd.h>
+
+int print_reverse_iterative(char *str) {
+    int len = strlen(str);
+    for (int i = len - 1; i >= 0; i--) {
+        write(1, &str[i], 1);
+    }
+    return 0;
+}
+
+int print_reverse_recursive(char *str) {
+    if (!*str)
+        return 1;
+    if (print_reverse_recursive(str + 1) == 1) {
+        write(1, str, 1);
+        return 1;
+    }
+    return -1;
+}

--- a/print_reverse.h
+++ b/print_reverse.h
@@ -1,8 +1,20 @@
 #ifndef PRINT_REVERSE_H
 #define PRINT_REVERSE_H
 
+/**
+ * Print the given string in reverse order using an iterative approach.
+ *
+ * @param str The input string to be printed in reverse.
+ * @return 0 on success, or -1 if an unexpected error occurs.
+ */
 int print_reverse_iterative(char *str);
 
+/**
+ * Print the given string in reverse order using a recursive approach.
+ *
+ * @param str The input string to be printed in reverse.
+ * @return 1 on success, or -1 if an unexpected error occurs.
+ */
 int print_reverse_recursive(char *str);
 
 #endif /* PRINT_REVERSE_H */

--- a/print_reverse.h
+++ b/print_reverse.h
@@ -1,29 +1,8 @@
 #ifndef PRINT_REVERSE_H
 #define PRINT_REVERSE_H
 
-#include <string.h>
-#include <unistd.h>
+int print_reverse_iterative(char *str);
 
-/* APPROACH 1 */
-inline int print_reverse_iterative(char *str) {
-    int len = strlen(str);  /* Determine the length of the input string. */
-    for (int i = len - 1; i >= 0; i--) {  /* Loop through the characters of the string in reverse order. */
-        write(1, &str[i], 1);  /* Write each character to standard output. */
-    }
-    return 0;  /* Return zero to indicate success. */
-}
-
-/* APPROACH 2 */
-inline int print_reverse_recursive(char *str)
-{
-    if (!*str)
-        return 1;
-    if (print_reverse_recursive(str + 1) == 1)
-    {
-        write(1, str, 1);
-        return 1;
-    }
-    return -1; /* that means, something unexcepted happened */
-}
+int print_reverse_recursive(char *str);
 
 #endif /* PRINT_REVERSE_H */


### PR DESCRIPTION
In this commit, I refactored the print_reverse_iterative and print_reverse_recursive functions by converting them from inline definitions in the header file to separate function declarations, and added function documentations. This change was made as I relearned C from the very start, and realized that while inlining could improve program performance, it could also increase compile times and binary sizes.

Considering that this repository is not a large project and unlikely to be widely used, this change doesn't really matter, but nonetheless I opted for good coding practices by providing separate declarations. This promotes maintainability, avoids code duplication, and keeps the codebase clean and organized.